### PR TITLE
Add logging when error occurred

### DIFF
--- a/src/DispenserProvider/DispenserProviderLambda.cs
+++ b/src/DispenserProvider/DispenserProviderLambda.cs
@@ -27,6 +27,7 @@ public class DispenserProviderLambda(IServiceProvider serviceProvider)
         }
         catch (Exception ex)
         {
+            LambdaLogger.Log(ex.ToString());
             return new LambdaResponse(ex);
         }
     }


### PR DESCRIPTION
I think no need to log when `ValidationException` occurred, because we anyway will return error data from `ValidationException` as result